### PR TITLE
Add Tabular VAE tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Datathon-WP7
+
+This repository contains a simple IPython tutorial demonstrating how to train a Variational Autoencoder (VAE) on tabular data and generate synthetic samples. See `TabularVAE_Tutorial.ipynb` for step-by-step guidance.

--- a/TabularVAE_Tutorial.ipynb
+++ b/TabularVAE_Tutorial.ipynb
@@ -1,0 +1,438 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "afdc21f1",
+   "metadata": {},
+   "source": [
+    "# Tabular Variational Autoencoder\n",
+    "This simple tutorial shows how to train a Variational Autoencoder (VAE) on a small table and generate synthetic rows. It's designed for a non-technical audience, so follow along step by step."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10eb885b",
+   "metadata": {},
+   "source": [
+    "## 1. Setup\n",
+    "Run the cell below to install the required libraries. If you're running in an environment that already has them, this step will finish quickly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b59f181b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-10T14:25:23.349190Z",
+     "iopub.status.busy": "2025-09-10T14:25:23.348875Z",
+     "iopub.status.idle": "2025-09-10T14:25:25.038886Z",
+     "shell.execute_reply": "2025-09-10T14:25:25.035828Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33mWARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.\u001b[0m\u001b[33m\r\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install torch pandas scikit-learn --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49b67269",
+   "metadata": {},
+   "source": [
+    "## 2. Load a sample dataset\n",
+    "We'll use the classic Iris flower dataset that comes with scikit-learn."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "70b40c71",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-10T14:25:25.052008Z",
+     "iopub.status.busy": "2025-09-10T14:25:25.051177Z",
+     "iopub.status.idle": "2025-09-10T14:25:27.311778Z",
+     "shell.execute_reply": "2025-09-10T14:25:27.310577Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset shape: (150, 4)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sepal length (cm)</th>\n",
+       "      <th>sepal width (cm)</th>\n",
+       "      <th>petal length (cm)</th>\n",
+       "      <th>petal width (cm)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>5.1</td>\n",
+       "      <td>3.5</td>\n",
+       "      <td>1.4</td>\n",
+       "      <td>0.2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>4.9</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1.4</td>\n",
+       "      <td>0.2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>4.7</td>\n",
+       "      <td>3.2</td>\n",
+       "      <td>1.3</td>\n",
+       "      <td>0.2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4.6</td>\n",
+       "      <td>3.1</td>\n",
+       "      <td>1.5</td>\n",
+       "      <td>0.2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5.0</td>\n",
+       "      <td>3.6</td>\n",
+       "      <td>1.4</td>\n",
+       "      <td>0.2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   sepal length (cm)  sepal width (cm)  petal length (cm)  petal width (cm)\n",
+       "0                5.1               3.5                1.4               0.2\n",
+       "1                4.9               3.0                1.4               0.2\n",
+       "2                4.7               3.2                1.3               0.2\n",
+       "3                4.6               3.1                1.5               0.2\n",
+       "4                5.0               3.6                1.4               0.2"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sklearn.datasets import load_iris\n",
+    "import pandas as pd\n",
+    "\n",
+    "iris = load_iris()\n",
+    "data = pd.DataFrame(iris.data, columns=iris.feature_names)\n",
+    "print('Dataset shape:', data.shape)\n",
+    "data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52d19943",
+   "metadata": {},
+   "source": [
+    "## 3. Build a simple VAE\n",
+    "This VAE has two main parts: an encoder that compresses the data and a decoder that rebuilds it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fd04531b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-10T14:25:27.315019Z",
+     "iopub.status.busy": "2025-09-10T14:25:27.314479Z",
+     "iopub.status.idle": "2025-09-10T14:25:31.000375Z",
+     "shell.execute_reply": "2025-09-10T14:25:30.999207Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch import nn\n",
+    "\n",
+    "class VAE(nn.Module):\n",
+    "    def __init__(self, input_dim, latent_dim=2):\n",
+    "        super().__init__()\n",
+    "        self.encoder = nn.Sequential(\n",
+    "            nn.Linear(input_dim, 8),\n",
+    "            nn.ReLU(),\n",
+    "            nn.Linear(8, latent_dim*2)\n",
+    "        )\n",
+    "        self.decoder = nn.Sequential(\n",
+    "            nn.Linear(latent_dim, 8),\n",
+    "            nn.ReLU(),\n",
+    "            nn.Linear(8, input_dim)\n",
+    "        )\n",
+    "\n",
+    "    def encode(self, x):\n",
+    "        h = self.encoder(x)\n",
+    "        mu, logvar = h.chunk(2, dim=1)\n",
+    "        return mu, logvar\n",
+    "\n",
+    "    def reparameterize(self, mu, logvar):\n",
+    "        std = (0.5*logvar).exp()\n",
+    "        eps = torch.randn_like(std)\n",
+    "        return mu + eps*std\n",
+    "\n",
+    "    def decode(self, z):\n",
+    "        return self.decoder(z)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        mu, logvar = self.encode(x)\n",
+    "        z = self.reparameterize(mu, logvar)\n",
+    "        recon = self.decode(z)\n",
+    "        return recon, mu, logvar\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05780585",
+   "metadata": {},
+   "source": [
+    "## 4. Train the model\n",
+    "We'll train for just a few epochs because the dataset is small."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b0846143",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-10T14:25:31.005876Z",
+     "iopub.status.busy": "2025-09-10T14:25:31.005489Z",
+     "iopub.status.idle": "2025-09-10T14:25:33.906290Z",
+     "shell.execute_reply": "2025-09-10T14:25:33.905020Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 0: loss=14.2252\n",
+      "Epoch 10: loss=1.6809\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 20: loss=1.3177\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 30: loss=0.9026\n",
+      "Epoch 40: loss=0.8603\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "from torch.utils.data import DataLoader, TensorDataset\n",
+    "\n",
+    "X = torch.tensor(data.values, dtype=torch.float32)\n",
+    "dataset = TensorDataset(X)\n",
+    "loader = DataLoader(dataset, batch_size=16, shuffle=True)\n",
+    "\n",
+    "model = VAE(input_dim=X.shape[1])\n",
+    "optimizer = torch.optim.Adam(model.parameters(), lr=0.01)\n",
+    "\n",
+    "for epoch in range(50):\n",
+    "    for batch in loader:\n",
+    "        batch = batch[0]\n",
+    "        recon, mu, logvar = model(batch)\n",
+    "        recon_loss = nn.functional.mse_loss(recon, batch)\n",
+    "        kl_loss = -0.5 * torch.mean(1 + logvar - mu.pow(2) - logvar.exp())\n",
+    "        loss = recon_loss + kl_loss\n",
+    "        optimizer.zero_grad()\n",
+    "        loss.backward()\n",
+    "        optimizer.step()\n",
+    "    if epoch % 10 == 0:\n",
+    "        print(f'Epoch {epoch}: loss={loss.item():.4f}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57d5c103",
+   "metadata": {},
+   "source": [
+    "## 5. Generate new synthetic rows\n",
+    "After training, we can sample new rows from the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1f41bda1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-10T14:25:33.910177Z",
+     "iopub.status.busy": "2025-09-10T14:25:33.909554Z",
+     "iopub.status.idle": "2025-09-10T14:25:33.924219Z",
+     "shell.execute_reply": "2025-09-10T14:25:33.923299Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sepal length (cm)</th>\n",
+       "      <th>sepal width (cm)</th>\n",
+       "      <th>petal length (cm)</th>\n",
+       "      <th>petal width (cm)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>5.900254</td>\n",
+       "      <td>2.903900</td>\n",
+       "      <td>4.240979</td>\n",
+       "      <td>1.386844</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>5.583257</td>\n",
+       "      <td>2.989634</td>\n",
+       "      <td>3.455221</td>\n",
+       "      <td>1.041633</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>5.535187</td>\n",
+       "      <td>3.204916</td>\n",
+       "      <td>2.698673</td>\n",
+       "      <td>0.713613</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>5.912194</td>\n",
+       "      <td>2.908473</td>\n",
+       "      <td>4.247410</td>\n",
+       "      <td>1.389859</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5.309346</td>\n",
+       "      <td>3.204262</td>\n",
+       "      <td>2.320914</td>\n",
+       "      <td>0.550678</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   sepal length (cm)  sepal width (cm)  petal length (cm)  petal width (cm)\n",
+       "0           5.900254          2.903900           4.240979          1.386844\n",
+       "1           5.583257          2.989634           3.455221          1.041633\n",
+       "2           5.535187          3.204916           2.698673          0.713613\n",
+       "3           5.912194          2.908473           4.247410          1.389859\n",
+       "4           5.309346          3.204262           2.320914          0.550678"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with torch.no_grad():\n",
+    "    z = torch.randn(5, 2)\n",
+    "    synthetic = model.decode(z).numpy()\n",
+    "synthetic_df = pd.DataFrame(synthetic, columns=iris.feature_names)\n",
+    "synthetic_df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17dda015",
+   "metadata": {},
+   "source": [
+    "You're now ready to adapt this notebook to your own tables. Replace the dataset loading step with your data and retrain the model."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add an IPython notebook showing how to train a small Variational Autoencoder (VAE) on tabular data and sample synthetic rows
- document the new tutorial in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c188a47b008332b003c889da518c43